### PR TITLE
Update run.sh, transition to Darknet

### DIFF
--- a/trekking/docker/Dockerfile
+++ b/trekking/docker/Dockerfile
@@ -38,7 +38,8 @@ RUN cd ~/opencv && mkdir build && cd build && cmake -DBUILD_DOCS=OFF -DBUILD_PER
     && make -j4 && make install && rm -rf ~/opencv*
 # NVIDIA CUB
 RUN git clone --depth=5 https://github.com/NVlabs/cub.git ~/cub && cd ~/cub \
-    && git checkout 1.5.5 && cp -r cub /usr/local/include/cub
+    && git reset --hard aeb2d43bf4c75a52874f9d73160fb762282417d6 \
+    && cp -r cub /usr/local/include/cub && rm -rf ~/cub
 
 
 # Caffe

--- a/trekking/docker/Dockerfile
+++ b/trekking/docker/Dockerfile
@@ -21,37 +21,6 @@ RUN useradd -mG sudo ros && echo source "/opt/ros/$ROS_DISTRO/setup.bash" >> ~ro
     && mkdir -p /etc/sudoers.d && echo '%sudo   ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/sudo_nopasswd
 
 
-# Caffe deps
-RUN apt-get update && apt-get install --no-install-recommends -y git gfortran \
-    libatlas-base-dev libboost-all-dev libgflags-dev libgoogle-glog-dev libhdf5-serial-dev \
-    libleveldb-dev liblmdb-dev libprotobuf-dev libsnappy-dev protobuf-compiler \
-    python-all-dev python-dev python-h5py python-matplotlib python-numpy \
-    python-pil python-pip python-protobuf python-scipy python-skimage python-sklearn \
-    && rm -rf /var/lib/apt/lists/*
-# OpenCV w/ CUDA
-RUN git clone https://github.com/opencv/opencv.git ~/opencv && cd ~/opencv \
-    && git reset --hard 10896129b39655e19e4e7c529153cb5c2191a1db
-RUN cd ~/opencv && mkdir build && cd build && cmake -DBUILD_DOCS=OFF -DBUILD_PERF_TESTS=OFF \
-    -DBUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=RELEASE -DCUDA_ARCH_BIN="3.0 3.5 5.0 6.1" \
-    -DCUDA_ARCH_PTX="3.0" -DCUDA_FAST_MATH=ON -DENABLE_FAST_MATH=ON -DENABLE_SSE41=ON \
-    -DENABLE_SSE42=ON -DENABLE_SSSE3=ON -DWITH_CUBLAS=ON -DWITH_MATLAB=OFF .. \
-    && make -j4 && make install && rm -rf ~/opencv*
-# NVIDIA CUB
-RUN git clone --depth=5 https://github.com/NVlabs/cub.git ~/cub && cd ~/cub \
-    && git reset --hard aeb2d43bf4c75a52874f9d73160fb762282417d6 \
-    && cp -r cub /usr/local/include/cub && rm -rf ~/cub
-
-
-# Caffe
-RUN git clone --depth=5 https://github.com/ThundeRatz/caffe ~/caffe && cd ~/caffe \
-    && git reset --hard 60748d7a0092a1fe52b267a5c350397032627446
-RUN pip install -U pip && pip install -r ~/caffe/python/requirements.txt && rm -rf ~/.cache/pip
-RUN mkdir -p ~/caffe/build && cd ~/caffe/build && cmake -DBUILD_docs=OFF -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=/usr/local -DOpenCV_DIR=/usr/local/share/OpenCV .. \
-    && make -j4 all && make install && rm -rf ~/caffe
-RUN echo export PYTHONPATH=/usr/local/python > /etc/profile.d/python-usr-local.sh
-
-
 # RTIMULib2
 RUN git clone --depth=5 https://github.com/richardstechnotes/RTIMULib2.git ~/RTIMULib2
 RUN mkdir ~/RTIMULib2/Linux/build && cd ~/RTIMULib2/Linux/build && cmake -DBUILD_GL=OFF .. \

--- a/trekking/run.sh
+++ b/trekking/run.sh
@@ -22,4 +22,9 @@ else
     DOCKER=docker
 fi
 
-$DOCKER run --rm --privileged -v "$trekking":/home/ros/ThunderTrekking -v /dev/bus/usb -v /tmp/.X11-unix:/tmp/.X11-unix:ro thunderatz/trekking
+CMD="$DOCKER run --rm --privileged -e DISPLAY=\"$DISPLAY\" -v \"$trekking\":/home/ros/ThunderTrekking -v /dev/bus/usb -v /tmp/.X11-unix:/tmp/.X11-unix:ro"
+if (( $# == 0 )) ; then
+    eval "$CMD thunderatz/trekking"
+else
+    eval "$CMD -ti thunderatz/trekking \"$*\""
+fi


### PR DESCRIPTION
WIP

Atualizações no run.sh facilitam a execução de comandos customizados ou abertura de um shell no container. Setar DISPLAY para o mesmo do host evita de fazer isso manualmente quando for usar alguma GUI.

Vou deixar o PR aberto por enquanto porque eu talvez mude de ideia quanto a tirar OpenCV (muita coisa depende dele no trekking). Dou merge se der tudo certo com Darknet e a gente abandonar todas as dependências de OpenCV.