### PR TITLE
Bump base container to cuda:9.1-cudnn7-devel-ubuntu16.04

### DIFF
--- a/trekking/docker/Dockerfile
+++ b/trekking/docker/Dockerfile
@@ -1,5 +1,5 @@
-FROM nvidia/cuda:8.0-cudnn5-devel-ubuntu16.04
-MAINTAINER Tiago Koji Castro Shibata
+FROM nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04
+LABEL maintainer="Tiago Koji Castro Shibata"
 
 
 # General setup

--- a/trekking/docker/run.sh
+++ b/trekking/docker/run.sh
@@ -13,7 +13,7 @@ fi
 if ! which nvidia-smi > /dev/null ; then
     echo "Can't find nvidia-smi, use nvidia-docker instead of docker and check host drivers installation"
 elif ! nvidia-smi > /dev/null ; then
-    echo "Failed to run nvidia-smi, check if host libraries are in place"
+    echo 'Failed to run nvidia-smi, check if host libraries are in place'
 fi
 
 if ! cd ~/ThunderTrekking/Main ; then


### PR DESCRIPTION
Estava com CUDA 8 há bastante tempo, acho que dá pra gente usar 9 nas nossas máquinas (a TX2 suporta 9.0)